### PR TITLE
docs: Pivot to QuantaGlia-Pruner module

### DIFF
--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -19,3 +19,20 @@
 ## Future Roadmap
 - [ ] Federated integration across machines?
 - [ ] Test in embedded or containerized environments
+
+---
+
+# Proposed Enhancements for QuantaGlia-Pruner
+
+## Learning & Adaptation
+- [ ] **Similarity Analysis:** Use NLP techniques (e.g., doc2vec, TF-IDF) to analyze the content of READMEs and other documents to identify redundant or similar repositories.
+- [ ] **Dependency Graph:** Build a dependency graph of the repositories in the knowledge base to avoid pruning repositories that are dependencies of others. This could be done by parsing `requirements.txt`, `package.json`, etc.
+- [ ] **Usage-Based Pruning:** Integrate more tightly with QuantaSensa to get fine-grained data on which pieces of knowledge are being actively used, and use this as a primary factor in pruning decisions.
+
+## Resilience Features
+- [ ] **Dry Run Mode:** Add a "dry run" mode to the pruner that simulates pruning actions and logs what would have been done without actually performing any destructive operations.
+- [ ] **Configurable Pruning Strategies:** Allow users to define different pruning strategies in the `config.yaml`, such as "conservative" (archive only), "aggressive" (delete aggressively), or "balanced".
+
+## Interoperability
+- [ ] **Webhook Notifications:** When a repository is pruned, send a webhook notification to a specified URL, allowing other systems to react to the change.
+- [ ] **Human-in-the-Loop:** For borderline cases, instead of making an autonomous decision, the pruner could flag the repository for human review and wait for approval before taking action.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,24 +1,40 @@
 # 📘 Module Planning Document
 
 ## Module Name
-- Placeholder: Quanta[NewModule] (e.g., QuantaCortex, QuantaThalamus)
+- QuantaGlia-Pruner
 
 ## Purpose
-- Define the purpose of this module in the QuantaSoft system.
-- What role does it play within the agent ecosystem?
+- To implement the intelligent, automated maintenance capabilities of the QuantaGlia system, as described in the `README.md`.
+- This module will be responsible for periodically evaluating repositories for redundancy, obsolescence, and low impact, and then merging, archiving, or deleting them based on configurable thresholds. This is a core component of the system's automated maintenance function.
 
 ## Goals
-- [ ] Define inputs and outputs
-- [ ] Define triggers and dependencies
-- [ ] Establish ethical decision logic (if applicable)
+- [x] **Define inputs and outputs**
+  - **Inputs:**
+    - `knowledge_base/`: The Pruner will scan this directory to evaluate the extracted knowledge from each repository.
+    - `quantaglia.log`: The log file will be used to determine repository age and usage patterns (e.g., how often a repository's knowledge is accessed, although this is a future enhancement).
+    - `config.yaml`: A configuration file specifying the pruning thresholds (e.g., `age_threshold_days`, `min_usage_score`).
+  - **Outputs:**
+    - Pruning actions (merge, archive, delete) performed on the repositories in the `knowledge_base` and `repo_cache`.
+    - Detailed logs in `quantaglia.log` with justifications for each pruning decision.
+- [x] **Define triggers and dependencies**
+  - **Triggers:** The pruner will be triggered periodically, based on a schedule defined in the `config.yaml` (e.g., `pruning.interval_minutes`). This will be managed by the `QuantaParent` scheduler.
+  - **Dependencies:**
+    - Python 3.x
+    - PyYAML for reading the configuration file.
+- [ ] **Establish ethical decision logic (if applicable)**
+  - Pruning decisions, especially deletion, are destructive. Therefore, the Pruner must integrate with `QuantaEthos`.
+  - Deletion actions must be logged with a high level of detail.
+  - An "archive" instead of "delete" policy will be the default for repositories that are not clearly redundant or useless, to prevent accidental knowledge loss.
 
 ## Integration Plan
 - How will this module communicate with:
-  - 🧠 QuantaSensa
-  - 🕊️ QuantaEthos
-  - 🧬 QuantaSynapse
-  - 🧹 QuantaGlia
+  - 🧠 **QuantaSensa:** QuantaSensa may provide signals about which knowledge is being used, which can inform the Pruner's `min_usage_score`.
+  - 🕊️ **QuantaEthos:** The Pruner must consult QuantaEthos before any destructive operation (delete/merge). Ethical guardrails will prevent the deletion of critical or ethically sensitive knowledge.
+  - 🧬 **QuantaSynapse:** The Pruner will update the QuantaSynapse knowledge graph to reflect the changes in the knowledge base (e.g., removing nodes for pruned repositories).
+  - 🧹 **QuantaGlia:** The Pruner is a core component of QuantaGlia. It will work alongside the existing repository cloner and information extractor.
 
 ## Notes
-- Anticipated constraints:
-- Potential edge cases:
+- **Anticipated constraints:**
+  - The logic for determining "redundancy" and "impact" can be complex. The initial version will rely on simple heuristics (e.g., age, presence of key files).
+- **Potential edge cases:**
+  - Handling of repositories that are part of a dependency chain. Pruning a repository that another depends on could cause issues. A dependency tracking mechanism will be needed.


### PR DESCRIPTION
This commit realigns the project plan to focus on the core automated maintenance functionality, per your feedback. The previous plan for a `QuantaGlia-Visualizer` has been replaced with a new plan for a `QuantaGlia-Pruner` module.

The changes include:
- Overwriting `docs/plan.md` with a detailed plan for the new Pruner module.
- Overwriting `docs/enhancements.md` with enhancement ideas relevant to the Pruner module.