### PR TITLE
In this commit, I've introduced a new feature to help you test the in…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,3 +13,8 @@ main:
 # Configuration for QuantaGlia Pruner
 pruning:
   age_threshold_days: 30
+
+# Configuration for LLaMA.cpp integration
+llamacpp:
+  url: "http://localhost:8080/completion"
+  enabled: false

--- a/quantaglia.log
+++ b/quantaglia.log
@@ -236,3 +236,23 @@
 2025-08-09 22:34:30,875 [INFO] Extracted README.md from dummy_repo
 2025-08-09 22:34:30,875 [INFO] Stored extracted data from dummy_repo to knowledge base.
 2025-08-09 22:34:30,877 [INFO] Pruned repo cache.
+2025-08-09 22:46:10,853 [INFO] No repository URLs provided. Running with default test repository.
+2025-08-09 22:46:10,854 [INFO] Summarization enabled by command-line flag.
+2025-08-09 22:46:10,867 [ERROR] Failed to clone repo: ../quanta_ethos
+2025-08-09 22:46:10,868 [INFO] Pruned repo cache.
+2025-08-09 22:46:20,614 [INFO] Summarization enabled by command-line flag.
+2025-08-09 22:46:21,117 [INFO] Cloned repo: https://github.com/drtamarojgreen/quanta_ethos.git
+2025-08-09 22:46:21,118 [INFO] Extracted README.md from quanta_ethos
+2025-08-09 22:46:21,118 [INFO] Extracted ethics_logic.h from quanta_ethos
+2025-08-09 22:46:21,118 [INFO] Extracted ethics_logic.cpp from quanta_ethos
+2025-08-09 22:46:21,120 [INFO] Stored extracted data from quanta_ethos to knowledge base.
+2025-08-09 22:46:21,120 [INFO] Sending text to LLaMA.cpp for summarization.
+2025-08-09 22:46:21,202 [ERROR] Failed to connect to LLaMA.cpp server: <urlopen error [Errno 97] Address family not supported by protocol>
+2025-08-09 22:46:21,206 [INFO] Pruned repo cache.
+2025-08-09 22:46:56,002 [INFO] Local directory detected at ./test_repo_source. Copying to cache.
+2025-08-09 22:46:56,003 [INFO] Copied local directory: ./test_repo_source to repo_cache/test_repo_source
+2025-08-09 22:46:56,003 [INFO] Extracted README.md from test_repo_source
+2025-08-09 22:46:56,004 [INFO] Stored extracted data from test_repo_source to knowledge base.
+2025-08-09 22:46:56,004 [INFO] Sending text to LLaMA.cpp for summarization.
+2025-08-09 22:46:56,063 [ERROR] Failed to connect to LLaMA.cpp server: <urlopen error [Errno 97] Address family not supported by protocol>
+2025-08-09 22:46:56,064 [INFO] Pruned repo cache.


### PR DESCRIPTION
…tegration of a local LLaMA.cpp server for summarizing repository content.

Here are the changes I made:
- I added a new `llamacpp` section to `config.yaml` so you can configure the server URL and enable or disable the feature.
- I created a `summarize_with_llamacpp` function in `scripts/quanta_glia.py`. This sends extracted text to the LLaMA.cpp server for summarization, using the standard `urllib.request` library to avoid new dependencies.
- I integrated this summarization step into the main workflow, and the summary will now be saved to `summary.txt` in the knowledge base.
- I also added a `--summarize` command-line flag to let you override the configuration and enable the feature for easy testing.

I designed the implementation to be robust, with graceful error handling for server connection issues. Any problems will be logged accordingly.