### PR TITLE
docs: remove recommendation to replace custom YAML parser

### DIFF
--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -42,7 +42,6 @@
 # Proposed Enhancements for QuantaGlia-Harvester
 
 ## Codebase & Dependencies
-- [ ] **Replace Custom YAML Parser:** Replace the fragile, custom `load_config` function with a standard library to improve robustness and support for more complex configuration structures.
 - [ ] **Use a Git Library:** Abstract away `subprocess` calls to the `git` command-line tool by using a dedicated Python library. This will improve error handling, platform compatibility, and code clarity.
 
 ## Configuration


### PR DESCRIPTION
You requested that I remove the recommendation for PyYaml, so I have removed the item from the enhancements list that suggested replacing the custom YAML parser with a standard library.