### PR TITLE
I've implemented the new, more sophisticated pruning mechanism you as…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,17 @@ main:
 # Configuration for QuantaGlia Pruner
 pruning:
   age_threshold_days: 30
+  strategy: "conservative" # conservative (archive) or aggressive (delete)
+  score_threshold: 50 # Repos below this score will be pruned
+  key_files:
+    - "README.md"
+    - "LICENSE"
+    - "CONTRIBUTING.md"
+    - "SECURITY.md"
+  weights:
+    age: 0.5
+    key_files: 0.3
+    size: 0.2
 
 # Configuration for LLaMA.cpp integration
 llamacpp:

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -81,19 +81,19 @@ python scripts/pruner.py --verbose
 ## Implementation Phases
 
 ### Phase 1: Foundational Pruner (Heuristic-Based)
-- [ ] Create the core `pruner.py` script.
-- [ ] Implement logic to read the `knowledge_base` directory.
-- [ ] Implement a simple age-based pruning rule (e.g., archive repos older than `age_threshold_days` from `config.yaml`).
-- [ ] Add robust logging for all decisions and actions.
-- [ ] Implement a "dry-run" command-line flag (`--dry-run`) to report what would be pruned.
+- [x] Create the core `pruner.py` script.
+- [x] Implement logic to read the `knowledge_base` directory.
+- [x] Implement a simple age-based pruning rule (e.g., archive repos older than `age_threshold_days` from `config.yaml`).
+- [x] Add robust logging for all decisions and actions.
+- [x] Implement a "dry-run" command-line flag (`--dry-run`) to report what would be pruned.
 
 ### Phase 2: Enhanced Logic & Safety
-- [ ] Develop a more sophisticated scoring model that combines multiple heuristics:
+- [x] Develop a more sophisticated scoring model that combines multiple heuristics:
   - Age of repository.
   - Presence/absence of key files (README, LICENSE, etc.).
   - Size and complexity (lines of code, number of files).
-- [ ] Implement configurable pruning strategies in `config.yaml` (e.g., `conservative`, `aggressive`).
-- [ ] Default to "archive" instead of "delete" for all operations.
+- [x] Implement configurable pruning strategies in `config.yaml` (e.g., `conservative`, `aggressive`).
+- [x] Default to "archive" instead of "delete" for all operations.
 
 ### Phase 3: Ethical Integration
 - [ ] Develop the API contract for communicating with `QuantaEthos`.

--- a/scripts/pruner.py
+++ b/scripts/pruner.py
@@ -25,12 +25,81 @@ from scripts.utils import load_config
 logging.basicConfig(
     filename='quantaglia.log',
     filemode='a',
-    level=logging.DEBUG,
+    level=logging.INFO, # Default to INFO, verbose flag will set it to DEBUG
     format='%(asctime)s [%(levelname)s] %(message)s'
 )
 
+def calculate_repo_score(repo_path: Path, pruning_config: dict) -> float:
+    """
+    Calculates a score for a repository based on age, key file presence, and size.
+
+    The score is a weighted average of three components:
+    1.  Age Score: Normalized based on the `age_threshold_days`. A brand new repo gets 100,
+        a repo at the age threshold gets 0.
+    2.  Key Files Score: Based on the presence of important files like README.md, LICENSE, etc.
+    3.  Size Score: Based on the number of files in the repository, capped at a reasonable limit.
+
+    Args:
+        repo_path: The path to the repository directory.
+        pruning_config: The pruning configuration dictionary from config.yaml.
+
+    Returns:
+        A score between 0 and 100.
+    """
+    now = datetime.now()
+    weights = pruning_config.get('weights', {'age': 0.5, 'key_files': 0.3, 'size': 0.2})
+    age_threshold_days = pruning_config.get('age_threshold_days', 30)
+    key_files_list = pruning_config.get('key_files', [])
+
+    # 1. Calculate Age Score
+    try:
+        mtime = repo_path.stat().st_mtime
+        last_modified_date = datetime.fromtimestamp(mtime)
+        age = now - last_modified_date
+        age_score = max(0, 100 * (1 - (age.days / age_threshold_days)))
+    except FileNotFoundError:
+        return 0 # Repo was likely deleted mid-scan
+
+    # 2. Calculate Key Files Score
+    found_key_files = 0
+    if key_files_list:
+        for key_file in key_files_list:
+            if (repo_path / key_file).exists():
+                found_key_files += 1
+        key_files_score = 100 * (found_key_files / len(key_files_list))
+    else:
+        key_files_score = 0
+
+    # 3. Calculate Size Score (based on file count)
+    num_files = sum(1 for _ in repo_path.glob('**/*') if _.is_file())
+    # Normalize size score, let's say 50 files is a "good" size for max score.
+    size_score = min(100, (num_files / 50.0) * 100)
+
+    # 4. Calculate final weighted score
+    final_score = (
+        weights.get('age', 0.5) * age_score +
+        weights.get('key_files', 0.3) * key_files_score +
+        weights.get('size', 0.2) * size_score
+    )
+
+    logging.debug(
+        f"Scoring for {repo_path.name}: "
+        f"Age={age.days}d (Score: {age_score:.1f}), "
+        f"KeyFiles={found_key_files}/{len(key_files_list)} (Score: {key_files_score:.1f}), "
+        f"Size={num_files} files (Score: {size_score:.1f}), "
+        f"Final Score: {final_score:.1f}"
+    )
+
+    return final_score
+
+
 def run_pruning(args):
     """Contains the core logic for pruning."""
+    if args.verbose:
+        # Set root logger level to DEBUG
+        logging.getLogger().setLevel(logging.DEBUG)
+        logging.info("Verbose logging enabled.")
+
     logging.info("Starting QuantaGlia Pruner.")
 
     config_data = load_config(args.config)
@@ -42,10 +111,14 @@ def run_pruning(args):
     pruning_config = config_data.get('pruning', {})
 
     KNOWLEDGE_BASE = Path(main_config.get("knowledge_base", "./knowledge_base"))
-    AGE_THRESHOLD_DAYS = pruning_config.get("age_threshold_days", 30)
+    SCORE_THRESHOLD = pruning_config.get("score_threshold", 50)
+
+    # Strategy can be overridden by command line argument, otherwise use config
+    strategy = args.strategy if args.strategy else pruning_config.get("strategy", "conservative")
 
     logging.info(f"Knowledge base: {KNOWLEDGE_BASE}")
-    logging.info(f"Age threshold (days): {AGE_THRESHOLD_DAYS}")
+    logging.info(f"Score threshold: {SCORE_THRESHOLD}")
+    logging.info(f"Pruning strategy: {strategy}")
 
     if args.dry_run:
         logging.info("Performing a DRY RUN. No files will be changed.")
@@ -56,37 +129,46 @@ def run_pruning(args):
         print(f"Error: Knowledge base directory not found at: {KNOWLEDGE_BASE}", file=sys.stderr)
         sys.exit(1)
 
-    now = datetime.now()
-    age_threshold = timedelta(days=AGE_THRESHOLD_DAYS)
-
-    logging.info(f"Scanning {KNOWLEDGE_BASE} for repositories older than {AGE_THRESHOLD_DAYS} days.")
+    logging.info(f"Scanning {KNOWLEDGE_BASE} for repositories to prune.")
 
     for repo_dir in KNOWLEDGE_BASE.iterdir():
         if repo_dir.is_dir():
             try:
-                mtime = repo_dir.stat().st_mtime
-                last_modified_date = datetime.fromtimestamp(mtime)
-                age = now - last_modified_date
+                score = calculate_repo_score(repo_dir, pruning_config)
+                logging.info(f"Repository '{repo_dir.name}' scored {score:.2f}")
 
-                if age > age_threshold:
-                    logging.info(f"Found old repository: {repo_dir.name} (age: {age.days} days). Preparing to archive.")
-                    archive_dir = Path("archive")
-                    archive_dir.mkdir(exist_ok=True)
-                    new_name = f"archive-{repo_dir.name}-age{age.days}"
-                    destination = archive_dir / new_name
+                if score < SCORE_THRESHOLD:
+                    logging.warning(f"Repo '{repo_dir.name}' with score {score:.2f} is below threshold {SCORE_THRESHOLD}.")
+
+                    if strategy == 'aggressive':
+                        action_verb = "delete"
+                        destination_info = ""
+                    else: # 'conservative'
+                        action_verb = "archive"
+                        # Use a more generic archive folder, perhaps in parent dir
+                        archive_dir = KNOWLEDGE_BASE.parent / "archive"
+                        archive_dir.mkdir(exist_ok=True)
+                        destination = archive_dir / f"{repo_dir.name}-score{score:.0f}"
+                        destination_info = f" to {destination}"
 
                     if args.dry_run:
-                        print(f"[DRY RUN] Would archive {repo_dir.name} to {destination}")
-                        logging.info(f"[DRY RUN] Would archive {repo_dir.name} to {destination}")
+                        print(f"[DRY RUN] Would {action_verb} {repo_dir.name}{destination_info}")
+                        logging.info(f"[DRY RUN] Would {action_verb} {repo_dir.name}{destination_info}")
                     else:
                         try:
-                            shutil.move(str(repo_dir), str(destination))
-                            print(f"Archived {repo_dir.name} to {destination}")
-                            logging.info(f"Archived {repo_dir.name} to {destination}")
+                            if strategy == 'aggressive':
+                                shutil.rmtree(repo_dir)
+                                print(f"Deleted {repo_dir.name}")
+                                logging.info(f"Deleted {repo_dir.name}")
+                            else: # 'conservative'
+                                shutil.move(str(repo_dir), str(destination))
+                                print(f"Archived {repo_dir.name}{destination_info}")
+                                logging.info(f"Archived {repo_dir.name}{destination_info}")
                         except Exception as e:
-                            logging.error(f"Failed to archive {repo_dir.name}: {e}")
+                            logging.error(f"Failed to {action_verb} {repo_dir.name}: {e}")
+
             except FileNotFoundError:
-                logging.warning(f"Could not stat directory {repo_dir}, it may have been removed.")
+                logging.warning(f"Could not stat directory {repo_dir}, it may have been removed mid-scan.")
 
 
 def main():
@@ -101,6 +183,17 @@ def main():
         "-c", "--config",
         default="config.yaml",
         help="Path to the configuration file (default: config.yaml)"
+    )
+    parser.add_argument(
+        "--strategy",
+        choices=["conservative", "aggressive"],
+        default=None,
+        help="Override the pruning strategy from config.yaml (conservative=archive, aggressive=delete)."
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable more detailed (DEBUG level) logging output."
     )
     args = parser.parse_args()
     run_pruning(args)


### PR DESCRIPTION
…ked for. Here is a summary of the changes:

-   **Scoring Model:** I've updated the pruner to calculate a score for each repository. This score is based on a weighted combination of age, the presence of key files (like README or LICENSE), and the total file count, allowing for more nuanced decisions than the previous age-only logic.
-   **Pruning Strategies:** The script now supports two strategies: `conservative` (which archives the repository) and `aggressive` (which deletes it). You can set your preference in `config.yaml` or override it using the new `--strategy` command-line argument.
-   **Configuration:** I updated the `config.yaml` file to include settings for the new scoring weights, score threshold, key files, and the default strategy.
-   **CLI Enhancements:** For better control and debugging, I added `--strategy` and `--verbose` flags to the pruner script.
-   **Documentation:** I also made sure to update the project's documentation to reflect these enhancements.