### PR TITLE
feat: Implement Phase 1 foundational pruner

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,14 +12,18 @@ main:
 
 # Configuration for QuantaGlia Pruner
 pruning:
-  age_threshold_days: 30
-  strategy: "conservative" # conservative (archive) or aggressive (delete)
-  score_threshold: 0.8 # Repos above this score will be pruned
-  weights:
-    usage: 0.5
-    age: 0.2
-    redundancy: 0.2
-    ethics: 0.1
+  # The interval in minutes for periodic pruning runs.
+  interval_minutes: 1440 # 24 hours
+
+  # Repositories older than this will be considered for pruning.
+  age_threshold_days: 90
+
+  # The default strategy for the pruner.
+  # "conservative": Archives repositories. Deletion is disabled.
+  default_strategy: "conservative"
+
+  # Path to the directory where archived repositories are moved.
+  archive_path: "repo_archive/"
 
 # Configuration for LLaMA.cpp integration
 llamacpp:


### PR DESCRIPTION
This commit implements the foundational pruner based on the specifications in `docs/phase_i_implementation.md`.

The previous complex, score-based logic in `scripts/pruner.py` has been replaced with a simpler, age-based archiving mechanism.

Key changes include:
- The pruner now identifies repositories for archival based on their last modification date, as configured by `age_threshold_days`.
- The default action is to move old repositories to an archive directory, specified by `archive_path` in the configuration.
- Structured JSONL logging has been implemented using the `JsonFormatter` utility.
- The `config.yaml` has been updated to support the new logic, removing score- and weight-based settings and adding `interval_minutes` and `archive_path`.
- The CLI now supports `--dry-run`, `--force`, and `--verbose` flags.
- Integration with `quanta_ethos.py` and the complex scoring model have been removed.

In accordance with your initial instructions, I did not run or modify the existing tests, as they are not applicable to this new implementation.