### PR TITLE
I am creating a new documentation file, `docs/research_tool_integrati…

### DIFF
--- a/docs/research_tool_integration.md
+++ b/docs/research_tool_integration.md
@@ -1,0 +1,72 @@
+# Research & Evaluation Framework Integration
+
+## 1. Introduction
+
+This document outlines how the Research & Evaluation Framework found in `scripts/app/` can be deeply integrated into the `QuantaGlia` workflow and the broader `Quanta Suite`. This framework provides a powerful, data-driven approach to content assessment, which can enhance and automate key processes in knowledge curation and governance.
+
+## 2. Overview of the Research & Evaluation Framework
+
+The framework, located in `scripts/app/`, is a modular system for programmatically evaluating text-based content. It operates on a set of "evaluation points," each representing an objective, verifiable check. Key features include:
+
+- **A rich set of validators**: Including `keyword` matching, `regex` patterns, `JSON schema` validation, semantic `embedding` similarity, and safe `code_test` execution.
+- **Aggregated Scoring**: The ability to combine results from multiple checks into a single, normalized quality score.
+- **Extensibility**: A clear pattern for adding new, custom validators to meet evolving requirements.
+
+By integrating this framework, we can replace manual or mocked assessments with automated, objective, and repeatable quality control.
+
+## 3. Integration with `quanta_glia.py` (Knowledge Harvester)
+
+The `quanta_glia.py` script is responsible for harvesting initial data from repositories. The evaluation framework can be integrated directly into this "ingestion" phase to provide an immediate quality filter and to enrich the harvested data.
+
+### Proposed Workflow:
+
+1.  **Harvest Content**: After `quanta_glia.py` clones a repository and extracts key files (e.g., `README.md`, `CONTRIBUTING.md`), the content is passed to the evaluation framework.
+2.  **Define Evaluation Sets**: A predefined set of `evaluation_points` would be created for different file types.
+    -   **For `README.md`**:
+        -   Check for the presence of `keyword`s like "Installation", "Usage", and "Configuration".
+        -   Use a `regex` check to ensure a "License" section exists.
+        -   Check for a minimum `length` to avoid empty or stub files.
+    -   **For `LICENSE`**:
+        -   Use `keyword` checks to identify the license type (e.g., "MIT", "Apache License 2.0").
+    -   **For `*.py` files**:
+        -   Use the `code_test` validator to run linters or basic syntax checks.
+        -   Use `regex` to check for the presence of docstrings.
+3.  **Store Evaluation Score**: The resulting quality score and detailed results would be stored as metadata alongside the harvested files in the `knowledge_base`. This provides an immediate, queryable metric of repository quality.
+
+This integration transforms the harvester from a simple data collector into a "quality-aware" ingestion engine.
+
+## 4. Integration with `pruner.py` (Knowledge Pruner)
+
+The `pruner.py` script currently relies on mocked scores for `usage_score`, `redundancy_score`, and `ethics_risk_score`. The evaluation framework is the perfect mechanism to replace these mocks with concrete, data-driven metrics.
+
+### Replacing Mocked Scores:
+
+-   **`usage_score`**: This can be directly calculated from the evaluation scores of a repository's documentation. A repository with a comprehensive, well-structured `README.md` is inherently more usable.
+    -   **Implementation**: The pruner would read the stored evaluation metadata for a repo's `README.md` and normalize it to a 0-1 `usage_score`.
+
+-   **`redundancy_score`**: The framework's `embedding` validator can be used to detect semantic overlap between repositories.
+    -   **Implementation**: The pruner could create a representative text blob for each repository (e.g., by concatenating its README and key source files). The `embedding` validator would then be used to calculate the similarity score between a repository and all others in the `knowledge_base`. A high average similarity would result in a high `redundancy_score`.
+
+-   **`ethics_risk_score`**: This can be calculated by scanning content for problematic terms or patterns.
+    -   **Implementation**: A dedicated set of `evaluation_points` would define ethical checks. This could include:
+        -   A `keyword` check for a list of non-inclusive terms.
+        -   A `regex` check to find hardcoded secrets or API keys.
+        The failure rate of these checks would directly translate into the `ethics_risk_score`.
+
+This integration makes the pruning process far more intelligent and defensible, as decisions to `ARCHIVE` or `DELETE` would be based on objective data rather than just file age.
+
+## 5. Integration with the Broader `Quanta Suite`
+
+The evaluation framework is a general-purpose utility that can serve numerous components within the larger `Quanta Suite`.
+
+-   **`QuantaEthos` (Ethical Governance)**: `QuantaEthos` could use the framework as its core enforcement mechanism. When another agent proposes an action (e.g., generating code, writing a document), `QuantaEthos` could use the framework to run a battery of ethical and safety checks on the content before approving it.
+
+-   **`QuantaCogno` (Cognitive Modeling)**: If a cognitive modeling agent is tasked with generating text (e.g., writing a new README or summarizing a complex topic), it can use the framework for self-assessment. By evaluating its own output against a set of criteria, it can iterate and improve its response before finalizing it.
+
+-   **`QuantaRetina` (Observation/Vision)**: If this component generates textual descriptions of visual data, the framework can be used to assess the quality and completeness of those descriptions. For example, ensuring that the description mentions key objects that were identified in the image.
+
+-   **CI/CD and Automated Testing**: The evaluation framework can be integrated into the CI/CD pipeline (`test_workspace.sh`) to automatically assess the quality of documentation and other text-based artifacts during every build, preventing quality regressions.
+
+## 6. Conclusion
+
+The Research & Evaluation Framework is a pivotal tool that brings data-driven intelligence to the Quanta ecosystem. By integrating it into the `QuantaGlia` harvesting and pruning workflows, we can automate quality control and make more informed decisions about our knowledge assets. Its potential extends across the entire `Quanta Suite`, providing a unified mechanism for ensuring the quality, safety, and utility of any text-based content generated or managed by the system.


### PR DESCRIPTION
…on.md`, that will describe how the research and evaluation framework in `scripts/app/` can be integrated into the `QuantaGlia` workflow and the broader `Quanta Suite`.

The document will outline the potential for using the evaluation framework to:
- Assess the quality of harvested content in `quanta_glia.py`.
- Replace the mocked scoring metrics in `pruner.py` with data-driven scores for usage, redundancy, and ethics.
- Serve other components in the `Quanta Suite` like `QuantaEthos` and `QuantaCogno`.