### PR TITLE
Fix: Correct bootstrap script permissions by cloning into a local dir…

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -46,8 +46,13 @@ REPOS=(
     "quanta_cerebra"
 )
 
+# --- Configuration ---
+# ... (rest of the configuration remains the same)
+
+# Directory to clone sibling repositories into
+WORKSPACE_DIR="workspace"
+
 # Log file for the script's output
-# Use an absolute path to ensure we can write to it after changing directories
 LOG_FILE="$(pwd)/bootstrap_setup.log"
 
 # --- Script Logic ---
@@ -58,9 +63,10 @@ true > "$LOG_FILE"
 echo "🚀 Starting QuantaGlia workspace bootstrap..." | tee -a "$LOG_FILE"
 echo "Full log will be saved to: $LOG_FILE" | tee -a "$LOG_FILE"
 
-# Navigate to the parent directory (e.g., `workspace/`)
-echo "Navigating from '$(pwd)/' to parent directory..." | tee -a "$LOG_FILE"
-cd ..
+# Create and navigate to the workspace directory
+echo "Creating workspace directory at: '$(pwd)/$WORKSPACE_DIR/'" | tee -a "$LOG_FILE"
+mkdir -p "$WORKSPACE_DIR"
+cd "$WORKSPACE_DIR"
 echo "Now in '$(pwd)/'. Preparing to clone sibling repositories." | tee -a "$LOG_FILE"
 
 echo "Cloning required repositories from GitHub..." | tee -a "$LOG_FILE"


### PR DESCRIPTION
…ectory

The bootstrap.sh script was failing with permission errors because it attempted to clone sibling repositories into the parent directory (`..`), which is not always writable.

This commit modifies the script to create and use a `workspace` directory inside the `quanta_glia` repository folder. This ensures the script has the necessary permissions to clone the required repositories, allowing the multi-repository environment to be set up correctly.