### PR TITLE
Document checkins vs checkouts ledger and traceability across CHAI CDD docs

### DIFF
--- a/tests/chai/CDD_Cheat_Sheet.md
+++ b/tests/chai/CDD_Cheat_Sheet.md
@@ -80,3 +80,11 @@ Turns AI into a disciplined, real-world-aware collaborator. Prevents:
 *   Chaotic development
 
 **CDD: The AI coding safety net for real-world environments.**
+
+## **Checkins vs Checkouts (Must Know)**
+
+*   **`chai_checkins.md`** = backlog of not-yet-implemented or deferred work.
+*   **`chai_checkouts.md`** = completed sip history with artifact and observation evidence.
+
+**Rule:** If work is deferred, record it in checkins. If work is completed, record it in checkouts.
+This keeps CDD auditable and prevents hidden or untraceable progress.

--- a/tests/chai/CHAI_Lifecycle_Map.md
+++ b/tests/chai/CHAI_Lifecycle_Map.md
@@ -102,3 +102,11 @@ graph TD
 11. **AI Agent - Understanding Mode (AI_U):** The AI agent consumes the newly recorded **Facts (FACTS)** and **Card Results (RESULTS)**, updating its understanding of the environment and state. This completes one sip cycle, leading to the next iteration of planning.
 
 **Human Developer Oversight (dashed lines):** The human continuously monitors and can intervene at various points, especially during Reasoning Gate and Restrictions Engine checks, or by reviewing Observations and Facts. This ensures the AI remains aligned with the overall vision without micromanagement.
+
+## Checkin/Checkout Traceability Rule
+
+CDD lifecycle governance relies on two files:
+- **`chai_checkins.md`** captures what is still pending.
+- **`chai_checkouts.md`** captures what has been done and verified.
+
+This pairing provides end-to-end traceability across lifecycle stages and enforces evidence-based progress reporting.

--- a/tests/chai/CHAI_Workflow_Map.md
+++ b/tests/chai/CHAI_Workflow_Map.md
@@ -72,3 +72,11 @@ graph LR
 10. **Agent: Continue Loop:** The cycle repeats, with the agent now having an updated set of Facts to inform its planning for the next sip.
 
 This iterative loop ensures that CHAI development is disciplined, empirically grounded, and always moving forward with verified capabilities.
+
+## Checkins and Checkouts in the Workflow
+
+In addition to facts/cards, CDD workflow state is tracked through two companion logs:
+1. **`chai_checkins.md`** for planned/deferred work.
+2. **`chai_checkouts.md`** for completed sips and their empirical outcomes.
+
+A workflow step is not fully closed until completed work is reflected in **checkouts** and any remaining future work is reflected in **checkins**.

--- a/tests/chai/README.md
+++ b/tests/chai/README.md
@@ -163,3 +163,12 @@ CDD's profitability lies in solving existing business problems by **verifying re
 - **Audience:** Engineering teams, SREs, architects.
 
 **Core Strategy:** Do not sell CDD. Sell solutions to problems developers already complain about: broken environments, mysterious CI failures, and AI agent safety. CDD is the engine behind the product.
+
+## Checkins and Checkouts (CDD Work Ledger)
+
+CDD uses a dual-ledger model for iterative work tracking:
+- **`cdd/chai_checkins.md`** tracks planned, deferred, or unfinished sips.
+- **`cdd/chai_checkouts.md`** tracks completed sips, touched artifacts, and observed outcomes.
+
+Both files are required for traceability. Checkins preserve intent; checkouts preserve evidence.
+Together they define the operational loop: **propose -> implement -> observe -> record**.

--- a/tests/chai/cdd/README.md
+++ b/tests/chai/cdd/README.md
@@ -84,3 +84,25 @@ int main(int argc, char** argv) {
     - Parses stdout into `observed_results`.
     - Validates observed results against `@Results`.
     - Reports success or mismatch.
+
+## 5. CDD Checkins vs Checkouts
+
+CHAI CDD uses two complementary logs to make iterative development auditable and reproducible:
+
+- **`chai_checkins.md` (planned work):** Records pending or proposed sips/tasks that still need implementation.
+- **`chai_checkouts.md` (completed work):** Records completed sips/tasks, what changed, and the resulting observation(s).
+
+### Why checkouts matter
+- They create a durable execution history for CDD evolution over time.
+- They capture evidence-based outcomes (what was actually verified), not just intent.
+- They provide fast onboarding context for new contributors by linking each increment to artifacts and observations.
+
+### Expected checkout entry content
+A checkout entry should minimally include:
+1. **Sip/Capability name** (what was implemented).
+2. **Artifacts touched** (files or directories created/modified).
+3. **Observation(s)** (empirical result or validation status).
+4. **Notes** (optional: constraints, follow-ups, or corrections).
+
+Together, checkins + checkouts provide a complete CDD loop: propose -> implement -> observe -> record.
+


### PR DESCRIPTION
### Motivation

- Clarify and enforce the CDD traceability model by distinguishing planned/deferred work (`checkins`) from verified/completed work (`checkouts`).
- Ensure CHAI contributors record intent and empirical evidence so iterative sips remain auditable and prevent hidden or untraceable progress.

### Description

- Added a new “Checkins vs Checkouts” section to `tests/chai/CDD_Cheat_Sheet.md` that defines `chai_checkins.md` and `chai_checkouts.md` and the rule for recording deferred vs completed work. 
- Extended `tests/chai/CHAI_Lifecycle_Map.md` with a “Checkin/Checkout Traceability Rule” describing the two-file governance and how they provide end-to-end traceability. 
- Extended `tests/chai/CHAI_Workflow_Map.md` with “Checkins and Checkouts in the Workflow” guidance that defines when workflow steps are considered closed and how to reflect that in the ledgers. 
- Extended `tests/chai/README.md` and `tests/chai/cdd/README.md` with a “Checkins and Checkouts” / “CDD Work Ledger” section that specifies expected checkout entry content and the operational loop (`propose -> implement -> observe -> record`).

### Testing

- No automated tests were executed because this is a documentation-only change and does not modify executable code or test artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ed8aca148328bdee169e21d3833a)