### PR TITLE
Add Automated Build Tools and Installation Instructions for quanta_glia across Linux, macOS, and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,110 @@ Get up and running with QuantaGlia in a few simple steps.
 
 ---
 
+## 🛠️ Build and Installation (QuantaGlia C++ Toolkit)
+
+The `glia` executable is compiled natively from C++ source files, ensuring extreme performance, low resource footprints, and platform-native integration.
+
+We provide automated installation tools and explicit manual guidelines for **Linux, macOS, and Windows**.
+
+### 📋 Prerequisites
+
+Ensure you have the following installed on your system:
+- **CMake** (v3.16 or newer)
+- **C++ Compiler** with C++17 support:
+  - **Linux:** GCC (g++ 9+) or Clang (clang++ 9+)
+  - **macOS:** Xcode Command Line Tools / Clang
+  - **Windows:** Visual Studio 2022 (with "Desktop development with C++" workload) or MinGW-w64
+
+---
+
+### 💻 1. Linux & macOS Installation
+
+You can build and install QuantaGlia using our automated bash script or manually.
+
+#### Option A: Automated Installation (Recommended)
+Run the unified C++ installer. This script compiles the executable, runs verification tests, and installs it to `$HOME/.local/bin`.
+
+```bash
+bash scripts/install.sh
+```
+
+#### Option B: Manual Compilation & Path Setup
+If you prefer to perform the compilation steps manually:
+
+1. **Compile the binary:**
+   ```bash
+   mkdir -p build && cd build
+   cmake -DCMAKE_BUILD_TYPE=Release ..
+   cmake --build . --config Release -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
+   ```
+2. **Move the executable to your local bin directory:**
+   ```bash
+   mkdir -p $HOME/.local/bin
+   cp glia $HOME/.local/bin/glia
+   chmod +x $HOME/.local/bin/glia
+   ```
+3. **Configure your shell PATH:**
+   - **For Zsh (default on macOS):**
+     ```bash
+     echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+     source ~/.zshrc
+     ```
+   - **For Bash (default on most Linux distros):**
+     ```bash
+     echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+     source ~/.bashrc
+     ```
+
+---
+
+### 🪟 2. Windows Installation
+
+You can build and install QuantaGlia under Windows via PowerShell or Developer Command Prompt.
+
+#### Option A: Automated PowerShell Installation (Recommended)
+Run the automated installation script. This script automatically detects Visual Studio or MinGW, compiles the release binaries, copies the executable to `~/.glia/bin`, and permanently registers that folder in your User `PATH` environment variable.
+
+1. Open PowerShell as a standard user.
+2. Run the batch launcher:
+   ```cmd
+   scripts\install.bat
+   ```
+   *(Or run directly via PowerShell: `powershell -ExecutionPolicy Bypass -File scripts\install.ps1`)*
+
+#### Option B: Manual Command Prompt Compilation & Path Setup
+1. Open the **Developer Command Prompt for VS 2022** (or standard cmd if MinGW is in your path).
+2. **Compile the binary:**
+   ```cmd
+   mkdir build
+   cd build
+   cmake ..
+   cmake --build . --config Release
+   ```
+3. **Move the binary to an installation folder:**
+   ```cmd
+   mkdir "%USERPROFILE%\.glia\bin"
+   copy Release\glia.exe "%USERPROFILE%\.glia\bin\glia.exe"
+   ```
+4. **Append to your User PATH environment variable:**
+   ```cmd
+   setx PATH "%PATH%;%USERPROFILE%\.glia\bin"
+   ```
+   *(Restart your command prompt or IDE for changes to take effect).*
+
+---
+
+### 🔍 3. Verifying the Installation
+
+To confirm that `glia` is installed correctly and is accessible from any terminal, open a new shell window and run:
+
+```bash
+glia --help
+```
+If configured correctly, this will display the QuantaGlia interactive dashboard options and available commands!
+
+---
+
 QuantaGlia is a modular subsystem within the PrismQuanta framework designed to autonomously collect, curate, and evolve knowledge repositories through intelligent spawning and pruning. It ensures the knowledge base remains relevant, efficient, and focused on the mission at hand.
 
 ---

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -1,0 +1,15 @@
+@echo off
+rem ==============================================================================
+rem QuantaGlia Windows Installer Launcher
+rem
+rem This script launches the PowerShell installer under Windows.
+rem ==============================================================================
+
+echo Launching QuantaGlia PowerShell Installer...
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0install.ps1"
+if %errorlevel% neq 0 (
+    echo Error: Installer failed with code %errorlevel%
+    pause
+    exit /b %errorlevel%
+)
+pause

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,111 @@
+# ==============================================================================
+# QuantaGlia Unified Installer (Windows PowerShell)
+#
+# This script automates the process of building the quanta_glia (glia) C++ toolkit
+# and adding it to the user's PATH under Windows.
+#
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File scripts/install.ps1
+# ==============================================================================
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "====================================================" -ForegroundColor Blue
+Write-Host "         QuantaGlia C++ Installer (Windows)         " -ForegroundColor Blue
+Write-Host "====================================================" -ForegroundColor Blue
+
+# --- Dependency Check ---
+Write-Host "`n[1/5] Checking prerequisites..." -ForegroundColor Yellow
+
+# Check for CMake
+$cmake = Get-Command cmake -ErrorAction SilentlyContinue
+if (-not $cmake) {
+    Write-Error "❌ Error: cmake is not installed or not in your PATH. Please install CMake and try again."
+    exit 1
+} else {
+    $cmakeVersion = (cmake --version | Select-Object -First 1)
+    Write-Host "✓ Found CMake: $cmakeVersion" -ForegroundColor Green
+}
+
+# --- Compilation ---
+Write-Host "`n[2/5] Compiling QuantaGlia..." -ForegroundColor Yellow
+
+$RepoRoot = Resolve-Path "$PSScriptRoot\.."
+$BuildDir = Join-Path $RepoRoot "build"
+
+if (-not (Test-Path $BuildDir)) {
+    New-Item -ItemType Directory -Path $BuildDir | Out-Null
+}
+
+Set-Location $BuildDir
+
+Write-Host "Configuring project in $BuildDir..."
+# Let CMake automatically choose the best available compiler generator on Windows
+cmake ..
+
+Write-Host "Building 'glia' and 'sorrel_test' binaries in Release configuration..."
+cmake --build . --config Release
+
+$GliaBinary = Join-Path $BuildDir "Release\glia.exe"
+if (-not (Test-Path $GliaBinary)) {
+    # Fallback to single-configuration build location if no Release folder (e.g. MinGW)
+    $GliaBinary = Join-Path $BuildDir "glia.exe"
+}
+
+if (-not (Test-Path $GliaBinary)) {
+    Write-Error "❌ Error: 'glia.exe' executable was not built successfully."
+    exit 1
+}
+
+Write-Host "✓ Compilation successful!" -ForegroundColor Green
+
+# --- Verification / Testing ---
+Write-Host "`n[3/5] Running verification tests..." -ForegroundColor Yellow
+$TestBinary = Join-Path $BuildDir "Release\sorrel_test.exe"
+if (-not (Test-Path $TestBinary)) {
+    $TestBinary = Join-Path $BuildDir "sorrel_test.exe"
+}
+
+if (Test-Path $TestBinary) {
+    Write-Host "Running sorrel_test verification suite..."
+    & $TestBinary
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "✓ All verification tests passed perfectly!" -ForegroundColor Green
+    } else {
+        Write-Host "⚠️ Warning: Some verification tests failed. Proceeding with installation anyway." -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "ℹ️ No test binary found. Skipping test phase." -ForegroundColor Cyan
+}
+
+# --- Installation ---
+Write-Host "`n[4/5] Installing glia binary..." -ForegroundColor Yellow
+$InstallDir = Join-Path $Home ".glia\bin"
+
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir | Out-Null
+}
+
+Copy-Item $GliaBinary (Join-Path $InstallDir "glia.exe") -Force
+Write-Host "✓ Installed 'glia.exe' to (Join-Path $InstallDir 'glia.exe')" -ForegroundColor Green
+
+# --- Path Configuration ---
+Write-Host "`n[5/5] Configuring Environment PATH..." -ForegroundColor Yellow
+
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$NormalizedUserPaths = $UserPath -split ';' | ForEach-Object { $_.Trim().TrimEnd('\') }
+$NormalizedInstallDir = $InstallDir.Trim().TrimEnd('\')
+
+if ($NormalizedUserPaths -contains $NormalizedInstallDir) {
+    Write-Host "✓ '$InstallDir' is already in your User PATH!" -ForegroundColor Green
+} else {
+    Write-Host "Adding '$InstallDir' to your User PATH registry..." -ForegroundColor Yellow
+    $NewUserPath = "$UserPath;$InstallDir"
+    [Environment]::SetEnvironmentVariable("Path", $NewUserPath, "User")
+    Write-Host "✓ Successfully added '$InstallDir' to User PATH!" -ForegroundColor Green
+    Write-Host "ℹ️ Please restart your terminal/IDE for the PATH changes to take effect." -ForegroundColor Cyan
+}
+
+Write-Host "`n====================================================" -ForegroundColor Green
+Write-Host "           QuantaGlia Build Completed!             " -ForegroundColor Green
+Write-Host "====================================================" -ForegroundColor Green

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# ==============================================================================
+# QuantaGlia Unified Installer (Linux / macOS)
+#
+# This script automates the process of building the quanta_glia (glia) C++ toolkit
+# and adding it to the user's PATH.
+#
+# Usage:
+#   bash scripts/install.sh
+# ==============================================================================
+
+set -e
+
+# --- Colors for Output ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}====================================================${NC}"
+echo -e "${BLUE}       QuantaGlia C++ Installer (Linux/macOS)       ${NC}"
+echo -e "${BLUE}====================================================${NC}"
+
+# --- Dependency Check ---
+echo -e "\n${YELLOW}[1/5] Checking prerequisites...${NC}"
+
+# Check for CMake
+if ! command -v cmake &> /dev/null; then
+    echo -e "${RED}❌ Error: cmake could not be found. Please install CMake and try again.${NC}"
+    exit 1
+else
+    CMAKE_VER=$(cmake --version | head -n1)
+    echo -e "${GREEN}✓ Found CMake: ${CMAKE_VER}${NC}"
+fi
+
+# Check for Compiler (g++ or clang++)
+COMPILER=""
+if command -v g++ &> /dev/null; then
+    COMPILER="g++"
+elif command -v clang++ &> /dev/null; then
+    COMPILER="clang++"
+fi
+
+if [ -z "$COMPILER" ]; then
+    echo -e "${RED}❌ Error: No suitable C++ compiler (g++ or clang++) found.${NC}"
+    exit 1
+else
+    echo -e "${GREEN}✓ Found C++ Compiler: ${COMPILER}${NC}"
+fi
+
+# --- Compilation ---
+echo -e "\n${YELLOW}[2/5] Compiling QuantaGlia...${NC}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build"
+
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+echo -e "Configuring project in ${BUILD_DIR}..."
+cmake -DCMAKE_BUILD_TYPE=Release ..
+
+echo -e "Building 'glia' and 'sorrel_test' binaries..."
+# Use available CPU cores for faster compilation
+CORES=1
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    CORES=$(nproc 2>/dev/null || echo 1)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    CORES=$(sysctl -n hw.ncpu 2>/dev/null || echo 1)
+fi
+cmake --build . --config Release -j "$CORES"
+
+# Check if build produced the glia executable
+if [ ! -f "glia" ]; then
+    echo -e "${RED}❌ Error: 'glia' executable was not built successfully.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Compilation successful!${NC}"
+
+# --- Verification / Testing ---
+echo -e "\n${YELLOW}[3/5] Running verification tests...${NC}"
+if [ -f "sorrel_test" ]; then
+    echo "Running sorrel_test verification suite..."
+    if ./sorrel_test; then
+        echo -e "${GREEN}✓ All verification tests passed perfectly!${NC}"
+    else
+        echo -e "${YELLOW}⚠️ Warning: Some verification tests failed. Proceeding with installation anyway.${NC}"
+    fi
+else
+    echo -e "${YELLOW}ℹ️ No test binary found. Skipping test phase.${NC}"
+fi
+
+# --- Installation ---
+echo -e "\n${YELLOW}[4/5] Installing glia binary...${NC}"
+INSTALL_DIR="$HOME/.local/bin"
+mkdir -p "$INSTALL_DIR"
+
+cp glia "$INSTALL_DIR/glia"
+chmod +x "$INSTALL_DIR/glia"
+
+echo -e "${GREEN}✓ Installed 'glia' to ${INSTALL_DIR}/glia${NC}"
+
+# --- Path Configuration ---
+echo -e "\n${YELLOW}[5/5] Configuring Environment PATH...${NC}"
+
+# Normalize paths for comparison
+REAL_INSTALL_DIR=$(cd "$INSTALL_DIR" && pwd)
+PATH_CONTAINS_GLIA=false
+
+# Check if INSTALL_DIR is in the active PATH
+IFS=':' read -r -a PATH_DIRS <<< "$PATH"
+for dir in "${PATH_DIRS[@]}"; do
+    if [ -d "$dir" ]; then
+        REAL_DIR=$(cd "$dir" 2>/dev/null && pwd || true)
+        if [ "$REAL_DIR" == "$REAL_INSTALL_DIR" ]; then
+            PATH_CONTAINS_GLIA=true
+            break
+        fi
+    fi
+done
+
+if [ "$PATH_CONTAINS_GLIA" = true ]; then
+    echo -e "${GREEN}✓ '${INSTALL_DIR}' is already in your PATH!${NC}"
+    echo -e "${GREEN}🎉 Setup complete! You can run 'glia' directly from any terminal.${NC}"
+else
+    echo -e "${YELLOW}⚠️ '${INSTALL_DIR}' is NOT in your current PATH.${NC}"
+    echo -e "To run 'glia' directly, please add it to your profile. Here is how:"
+
+    SHELL_NAME=$(basename "$SHELL")
+    RC_FILE=""
+
+    case "$SHELL_NAME" in
+        zsh)
+            RC_FILE="$HOME/.zshrc"
+            ;;
+        bash)
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                RC_FILE="$HOME/.bash_profile"
+            else
+                RC_FILE="$HOME/.bashrc"
+            fi
+            ;;
+        *)
+            RC_FILE="$HOME/.profile"
+            ;;
+    esac
+
+    echo -e "\nRun the following command to add it to your ${RC_FILE}:"
+    echo -e "${BLUE}  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ${RC_FILE}${NC}"
+    echo -e "Then, reload your shell configuration using:"
+    echo -e "${BLUE}  source ${RC_FILE}${NC}"
+
+    # Attempt to automatically add it for standard bash/zsh configurations
+    if [ -f "$RC_FILE" ]; then
+        echo -e "\nWould you like me to append this export statement to ${RC_FILE} automatically? (y/n)"
+        # Since we are in an automated sandbox environment, we can do it non-interactively if requested, or just instruct.
+        # But we can also make the script gracefully accept environment var or try to read input, but let's just make it do it if run with -y or fallback.
+        read -r response </dev/tty 2>/dev/null || response="n"
+        if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+            echo -e "\nexport PATH=\"\$HOME/.local/bin:\$PATH\"" >> "$RC_FILE"
+            echo -e "${GREEN}✓ Successfully added to ${RC_FILE}!${NC}"
+            echo -e "Please run ${BLUE}source ${RC_FILE}${NC} to refresh your current session."
+        else
+            echo -e "Please add it manually using the instructions above."
+        fi
+    fi
+fi
+
+echo -e "\n${GREEN}====================================================${NC}"
+echo -e "${GREEN}           QuantaGlia Build Completed!             ${NC}"
+echo -e "${GREEN}====================================================${NC}\n"

--- a/src/platform/platform.cpp
+++ b/src/platform/platform.cpp
@@ -1,8 +1,17 @@
 #include "platform.h"
 #include <cstdlib>
 #include <filesystem>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <psapi.h>
+#include <io.h>
+#define STDOUT_FILENO 1
+#define isatty _isatty
+#else
 #include <unistd.h>
 #include <sys/resource.h>
+#endif
 
 namespace glia::platform {
 std::string Environment::getVar(const std::string& name) {
@@ -15,6 +24,13 @@ bool Environment::isTerminal() {
 }
 
 long Environment::getMemoryUsage() {
+#ifdef _WIN32
+    PROCESS_MEMORY_COUNTERS pmc;
+    if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc))) {
+        return pmc.WorkingSetSize / 1024; // Bytes to KB
+    }
+    return 0;
+#else
     struct rusage usage;
     if (getrusage(RUSAGE_SELF, &usage) == 0) {
 #ifdef __APPLE__
@@ -24,9 +40,22 @@ long Environment::getMemoryUsage() {
 #endif
     }
     return 0;
+#endif
 }
 
 double Environment::getCpuUsage() {
+#ifdef _WIN32
+    FILETIME createTime, exitTime, kernelTime, userTime;
+    if (GetProcessTimes(GetCurrentProcess(), &createTime, &exitTime, &kernelTime, &userTime)) {
+        ULARGE_INTEGER kernel, user;
+        kernel.LowPart = kernelTime.dwLowDateTime;
+        kernel.HighPart = kernelTime.dwHighDateTime;
+        user.LowPart = userTime.dwLowDateTime;
+        user.HighPart = userTime.dwHighDateTime;
+        return (kernel.QuadPart + user.QuadPart) / 10000000.0; // convert 100-ns intervals to seconds
+    }
+    return 0.0;
+#else
     struct rusage usage;
     if (getrusage(RUSAGE_SELF, &usage) == 0) {
         double utime = usage.ru_utime.tv_sec + usage.ru_utime.tv_usec / 1000000.0;
@@ -34,6 +63,7 @@ double Environment::getCpuUsage() {
         return utime + stime;
     }
     return 0.0;
+#endif
 }
 
 std::string FileSystem::canonical(const std::string& path) {

--- a/src/util/shell_utils.h
+++ b/src/util/shell_utils.h
@@ -5,7 +5,14 @@
 #include <array>
 #include <cstdio>
 #include <stdexcept>
+
+#ifdef _WIN32
+#include <io.h>
+#define popen _popen
+#define pclose _pclose
+#else
 #include <sys/wait.h>
+#endif
 
 namespace glia::util {
 
@@ -23,7 +30,11 @@ inline ExecResult exec(const char* cmd, const std::string& cwd = "") {
     if (!pipe) throw std::runtime_error("popen");
     while (fgets(buffer.data(), buffer.size(), pipe) != nullptr) result += buffer.data();
     int status = pclose(pipe);
+#ifdef _WIN32
+    int exitCode = status;
+#else
     int exitCode = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+#endif
     return {result, exitCode};
 }
 


### PR DESCRIPTION
This PR implements the build tools, automated installers, path configuration, and associated manual instructions for compiling and installing quanta_glia (built as the 'glia' binary) on Linux, macOS, and Windows. To make this functional on Windows, POSIX-specific APIs in the core codebase have been refactored under conditional compilation blocks to utilize native Windows API equivalents (such as GetProcessMemoryInfo, GetProcessTimes, and _popen), preserving full Linux and macOS compatibility. All verification tests pass successfully.

---
*PR created automatically by Jules for task [7587042699269097816](https://jules.google.com/task/7587042699269097816) started by @drtamarojgreen*